### PR TITLE
Fix performance issue

### DIFF
--- a/src/utils/torch_macs.py
+++ b/src/utils/torch_macs.py
@@ -186,6 +186,9 @@ class MACCounterMode(TorchDispatchMode):
             total /= 1e9
         return total
 
+    def change_debug(self, debug):
+        self.debug = debug
+
     def __enter__(self):
         self.mac_counts.clear()
         super().__enter__()

--- a/src/utils/torchtraining.py
+++ b/src/utils/torchtraining.py
@@ -212,6 +212,8 @@ def full_training(model: PeftModel,
         save_results_file(results, run.name, run.id)
         logger.info("Initial evaluation done. Results: %s", results)
 
+    m_counter = MACCounterMode(model, show = True)
+
     #* WORKING LOOP
     for iteration in range(iters_need):
         loader_index = iteration % number_of_shards
@@ -225,7 +227,6 @@ def full_training(model: PeftModel,
         #* TRAINING
         logger.debug("Starting to train, iteration %d", iteration)
 
-        m_counter = MACCounterMode(model, show = iteration==0)
         with m_counter:
             start_time = time.time()
             model, running_loss, train_tests = train_entire_batch(model, tokenizer,
@@ -238,6 +239,8 @@ def full_training(model: PeftModel,
         if iteration == 0:
             run.summary["macs_per_step"] = (m_counter.get_total(divided=False)
                                             / len(train_loaders[0].dataset)) # type: ignore
+            m_counter.change_debug(False)
+
         steps_done += len(train_loaders[loader_index].dataset) # type: ignore
         time_done += (end_time - start_time)
 


### PR DESCRIPTION
The problem is that as the evaluation went on the time required for evaluating on test. After profiles it showed that torch_macs was the culprit, meaning that torch_macs was being executed on test. That however, didn't explain why the time increased in each iteration. After some meditating I think that the implementation of the mode made that if a new mode was created each time prehook functions would stack on each model firing causing an ever increasing need for resources. This commit should fix that. As a TODO it would be that an extra cost would still apply in test even if torch_macs isn't used, but, at least, it won't be an increasing cost.

![Llorera](https://github.com/Markel/PEFT-by-time/assets/45839898/6cfeb2f9-f6ac-4f21-8ddb-becb2e8e3270)